### PR TITLE
fix: Auth0: Undefined array key "email"

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -74,7 +74,7 @@ class Provider extends AbstractProvider
             'id'       => $user['sub'],
             'nickname' => $user['nickname'],
             'name'     => Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', ''),
-            'email'    => $user['email'],
+            'email'    => Arr::get($user, 'email'),
             'avatar'   => null,
         ]);
     }


### PR DESCRIPTION
Hi there!

A small suggestion to use Arr::get to get the email claim from the $user in the `mapUserToObject` for the Auth0 Provider. 

In some cases, there may be a different claim to identify the $user other than the email. (As odd as this may sound!)

At the moment,  if the specified 'email' key is not present in the $user array we get an exception when doing: `Socialite::driver('auth0')->user();`

![image](https://github.com/SocialiteProviders/Auth0/assets/8326558/b5d8afd1-27b3-421e-9e23-85380e5948b6)

Thank you for your work maintaining this!

